### PR TITLE
add macapp as valid signing format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [3.0.1] - 2017-06-02
+### Fixed
+- accept the `macapp` signing format, and translate it to `dmg` for the signing servers.
 
 ## [3.0.0] - 2017-03-23
 ### Changed

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ deps = [
 
 setup(
     name="signtool",
-    version="3.0.0",
+    version="3.1.0",
     description="Mozilla Signing Tool",
     author="Release Engineers",
     author_email="release+python@mozilla.com",

--- a/signtool/signtool.py
+++ b/signtool/signtool.py
@@ -18,7 +18,7 @@ from signtool.util.paths import findfiles
 
 ALLOWED_FORMATS = (
     "sha2signcode", "signcode", "osslsigncode", "gpg", "mar", "dmg",
-    "jar", "emevoucher"
+    "jar", "emevoucher", "macapp",
 )
 
 log = logging.getLogger(__name__)
@@ -190,6 +190,9 @@ def sign(options, args):
     for fmt in options.formats:
         urls = options.format_urls[fmt][:]
         random.shuffle(urls)
+
+        if fmt in ("macapp", ):
+            fmt = "dmg"
 
         log.debug("doing %s signing", fmt)
         log.debug("possible hosts are %s" % urls)

--- a/tests/test_signtool.py
+++ b/tests/test_signtool.py
@@ -59,11 +59,12 @@ def sign_options():
         "gpg": ["gpgurl1", "gpgurl2"],
         "signcode": ["signcodeurl1", "signcodeurl2"],
         "dmg": ["dmgurl1", "dmgurl2"],
+        "macapp": ["dmgurl1", "dmgurl2"],
     }
     options.includes = ['cert']
     options.excludes = []
     options.output_dir = None
-    options.formats = ["dmg", "signcode", "gpg"]
+    options.formats = ["dmg", "signcode", "gpg", "macapp"]
     return options
 
 


### PR DESCRIPTION
also macapp -> dmg for signing server.

This looks slightly different from the tools patch because I dropped `dmgv2` from py3 signtool, since everything had been ported to `dmgv2` on the buildbot side.  We don't use `dmg` anymore; just there for backwards compatibility.  It's a little more confusing now, but when we're off buildbot, it'll make more sense.

If we end up signing dmg's, I may resurrect the `dmg` signing format.  At that point, `macapp` will be for signing internals, and `dmg` would be for signing the external format.  That would involve patches for signing server, signtool, and in-tree graph scopes.