### PR TITLE
Bug 1380536 - update py3 signtool with sha384 mar + sha2signcodestub

### DIFF
--- a/signtool/signtool.py
+++ b/signtool/signtool.py
@@ -17,8 +17,8 @@ from signtool.util.paths import findfiles
 
 
 ALLOWED_FORMATS = (
-    "sha2signcode", "signcode", "osslsigncode", "gpg", "mar", "dmg",
-    "jar", "emevoucher", "macapp",
+    "sha2signcode", "sha2signcodestub", "signcode", "osslsigncode", "gpg",
+    "mar", "mar_sha384", "dmg", "jar", "emevoucher", "macapp",
 )
 
 log = logging.getLogger(__name__)
@@ -203,7 +203,8 @@ def sign(options, args):
         for f in files:
             log.debug("%s", f)
             log.debug("checking %s for signature...", f)
-            if fmt in ('sha2signcode', 'signcode', 'osslsigncode') and is_authenticode_signed(f):
+            if fmt in ('sha2signcode', 'sha2signcodestub', 'signcode', 'osslsigncode') \
+                    and is_authenticode_signed(f):
                 log.info("Skipping %s because it looks like it's already signed", f)
                 continue
             if options.output_dir:


### PR DESCRIPTION
Sorry, I stole that bug from you @escapewindow. I hope this makes things moving faster.

I analyzed https://hg.mozilla.org/build/tools/rev/591dd2cb8e26, https://hg.mozilla.org/build/tools/rev/d46034fed7e5 and what signtool is in this repo. IIUC, signtool here, is a copy of signtool.py, and nothing more. This means, signingscript.py and the ini files are run separately (on the signing servers). 

If that's correct, then we don't need a lot to add (see patch). If not, I'm sorry for the loss of time, and I'd be happy to review the next patch :) 