### PR TITLE
bug 1383769 - support widevine in signtool py3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.1.4] - 2017-08-04
+### Added
+- added widevine support
+
 ## [3.1.3] - 2017-07-13
 ### Changed
 - stop using pefile; verify windows signatures more efficiently

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ deps = [
 
 setup(
     name="signtool",
-    version="3.1.3",
+    version="3.1.4",
     description="Mozilla Signing Tool",
     author="Release Engineers",
     author_email="release+python@mozilla.com",

--- a/signtool/signing/client.py
+++ b/signtool/signing/client.py
@@ -49,6 +49,8 @@ def remote_signfile(options, urls, filename, fmt, token, dest=None):
 
     if fmt == 'gpg':
         dest += '.asc'
+    elif fmt in ('widevine', 'widevine_blessed'):
+        dest += '.sig'
 
     parent_dir = os.path.dirname(os.path.abspath(dest))
     if not os.path.exists(parent_dir):

--- a/signtool/signtool.py
+++ b/signtool/signtool.py
@@ -17,8 +17,19 @@ from signtool.util.paths import findfiles
 
 
 ALLOWED_FORMATS = (
-    "sha2signcode", "sha2signcodestub", "signcode", "osslsigncode", "gpg",
-    "mar", "mar_sha384", "dmg", "jar", "emevoucher", "macapp",
+    "dmg",
+    "emevoucher",
+    "gpg",
+    "jar",
+    "macapp",
+    "mar",
+    "mar_sha384",
+    "osslsigncode",
+    "sha2signcode",
+    "sha2signcodestub",
+    "signcode",
+    "widevine",
+    "widevine_blessed",
 )
 
 log = logging.getLogger(__name__)
@@ -168,12 +179,13 @@ def parse_cmdln_opts(parser, cmdln_args):
         else:
             formats.append(fmt)
 
-    # bug 1164456
-    # GPG signing must happen last because it will be invalid if done prior to
-    # any format that modifies the file in-place.
-    if "gpg" in formats:
-        formats.remove("gpg")
-        formats.append("gpg")
+    # bug 1382882, 1164456
+    # Widevine and GPG signing must happen last because they will be invalid if
+    # done prior to any format that modifies the file in-place.
+    for fmt in ("widevine", "widevine_blessed", "gpg"):
+        if fmt in formats:
+            formats.remove(fmt)
+            formats.append(fmt)
 
     if options.output_file and (len(args) > 1 or os.path.isdir(args[0])):
         parser.error(

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     py27
-    py33
     py34
     py35
 


### PR DESCRIPTION
This is the signtool py3 portion; we'll need a new signtool release and puppet patch to bump the signing scriptworkers once this lands.