### PR TITLE
Retry for ConnectionError during upload.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ matrix:
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
-    - python: 3.7-dev
+    - python: 3.7
+      dist: xenial
       env: TOXENV=py37
-  allow_failures:
-    - python: 3.7-dev
+      sudo: true
 
 install:
-    - python -mpip install tox
+    - travis_retry pip install tox
 script:
-    - tox -e "$TOX_ENVIRONMENT"
+    - tox
 after_success:
     - tox -e coveralls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.2.1] - 2018-08-27
+### Added
+- py3.6 and 3.7 support
+
+### Fixed
+- retry for `ConnectionError` during upload
+- various flake8 and test fixes
+
+### Removed
+- py3.4 support
+
 ## [3.2.0] - 2018-04-24
 ### Added
 - Added focus-jar support

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 from setuptools import setup, find_packages
 
@@ -9,7 +9,7 @@ deps = [
 
 setup(
     name="signtool",
-    version="3.2.0",
+    version="3.2.1",
     description="Mozilla Signing Tool",
     author="Release Engineers",
     author_email="release+python@mozilla.com",
@@ -32,5 +32,6 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ),
 )

--- a/signtool/signing/client.py
+++ b/signtool/signing/client.py
@@ -139,7 +139,7 @@ def remote_signfile(options, urls, filename, fmt, token, dest=None):
                 if six.PY3 and isinstance(nonce, six.text_type):
                     nonce = nonce.encode('utf-8')
                 open(options.noncefile, 'wb').write(nonce)
-            except requests.HTTPError as e:
+            except requests.RequestException as e:
                 log.exception("%s: error uploading file for signing: %s",
                               filehash, str(e))
                 urls.pop(0)


### PR DESCRIPTION
The `remote_signfile` function is pretty ugly and should be rewritten.
However, I believe we were failing to retry because we're in the except
block of the outer try/except, and the inner try/except didn't catch
`ConnectionError`. `RequestException` should catch both `HTTPError` and
`ConnectionError`.

Fixes https://github.com/mozilla-releng/signingscript/issues/66 .