### PR TITLE
don't randomize urls.

### DIFF
--- a/signtool/signtool.py
+++ b/signtool/signtool.py
@@ -9,7 +9,6 @@ import logging
 import os
 import sys
 from optparse import OptionParser
-import random
 import struct
 
 from signtool.signing.client import remote_signfile
@@ -237,7 +236,6 @@ def sign(options, args):
 
     for fmt in options.formats:
         urls = options.format_urls[fmt][:]
-        random.shuffle(urls)
 
         if fmt in ("macapp", ):
             fmt = "dmg"


### PR DESCRIPTION
To allow for server priority levels, let's handle the server/url
randomization in signingscript. Then let's not randomize a second time
in signtool.

See https://github.com/mozilla-releng/signingscript/issues/71