### PR TITLE
turn off timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.0.1] - 2019-05-31
+### Removed
+- Stopped adding timestamps to stdout
+
 ## [4.0.0] - 2019-04-01
 ### Added
 - sha2signcode-v2 support

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ deps = [
 
 setup(
     name="signtool",
-    version="4.0.0",
+    version="4.0.1",
     description="Mozilla Signing Tool",
     author="Release Engineers",
     author_email="release+python@mozilla.com",

--- a/signtool/signtool.py
+++ b/signtool/signtool.py
@@ -268,8 +268,7 @@ def main(name=None):
     if name in (None, '__main__'):
         parser = OptionParser(__doc__)
         options, args = parse_cmdln_opts(parser, sys.argv[1:])
-        logging.basicConfig(
-            level=options.log_level, format="%(asctime)s - %(message)s")
+        logging.basicConfig(level=options.log_level, format="%(message)s")
         log.debug("in %s", os.getcwd())
         sign(options, args)
         log.info("Done.")


### PR DESCRIPTION
We're already timestamping in signingscript logs, so we don't need to timestamp in signtool stdout.